### PR TITLE
Update Mathjax Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-
-* [mdBook](https://github.com/rust-lang/mdBook) fork from commit [1668ab7](https://github.com/montyly/mdBook/commit/1668ab78776ea966fa8ea4b335dd1394103d1cad)
-* Includes additional PRs: 
-    - [Add a logo to the navigation bar of the HTML rendered book](https://github.com/rust-lang/mdBook/pull/1584)
-    - [feat: Include Solidity and Yul highlighting ](https://github.com/montyly/mdBook/pull/1)
+- [mdBook](https://github.com/rust-lang/mdBook) fork from commit [1668ab7](https://github.com/montyly/mdBook/commit/1668ab78776ea966fa8ea4b335dd1394103d1cad)
+- Includes additional PRs:
+  - [Add a logo to the navigation bar of the HTML rendered book](https://github.com/rust-lang/mdBook/pull/1584)
+  - [feat: Include Solidity and Yul highlighting ](https://github.com/montyly/mdBook/pull/1)
+  - [feat: Change Mathjax parameters to render as HTML ](https://github.com/montyly/mdBook/pull/2)
 
 # mdBook
 
@@ -19,7 +19,7 @@ If you are interested in contributing to the development of mdBook, check out th
 
 ## License
 
-All the code in this repository is released under the ***Mozilla Public License v2.0***, for more information take a look at the [LICENSE] file.
+All the code in this repository is released under the **_Mozilla Public License v2.0_**, for more information take a look at the [LICENSE] file.
 
 [User Guide]: https://rust-lang.github.io/mdBook/
 [contribution guide]: https://github.com/rust-lang/mdBook/blob/master/CONTRIBUTING.md

--- a/src/theme/index.hbs
+++ b/src/theme/index.hbs
@@ -50,7 +50,7 @@
 
         {{#if mathjax_support}}
         <!-- MathJax -->
-        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+        <script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
         {{/if}}
     </head>
     <body>


### PR DESCRIPTION
Update Mathjax parameters to use the html renderer. Fixes a rendering issue:

Before:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/103113487/233924856-62926d33-4d00-4f12-b1ff-5b6248b16dc9.png">

After:
<img width="496" alt="image" src="https://user-images.githubusercontent.com/103113487/233924924-747960d5-5e7a-478d-8129-f250774a1683.png">
